### PR TITLE
fixed type export issue

### DIFF
--- a/lib/decorators.ts
+++ b/lib/decorators.ts
@@ -1,3 +1,1 @@
-import { SqsMessageHandler } from '@ssut/nestjs-sqs';
-
-export type { SqsMessageHandler };
+export { SqsMessageHandler } from '@ssut/nestjs-sqs';

--- a/lib/sqs.service.ts
+++ b/lib/sqs.service.ts
@@ -13,19 +13,19 @@ export class SqsService {
     receiptHandle: string,
   ): Promise<void> {
     try {
-      await this.sqsClient.deleteMessage({
-        QueueUrl: queueUrl,
-        ReceiptHandle: receiptHandle,
-      });
-    } catch (error) {
       if (this.sqsClient === undefined) {
         throw new Error(
           'SQS client not configured. Call configure method first.',
         );
       } else {
-        console.error('Error deleting message:', error);
-        throw error;
+        await this.sqsClient.deleteMessage({
+          QueueUrl: queueUrl,
+          ReceiptHandle: receiptHandle,
+        });
       }
+    } catch (error) {
+      console.error('Error deleting message:', error);
+      throw error;
     }
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@flocasts/nestjs-aws-sqs-connector",
-  "version": "0.0.1",
+  "version": "0.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@flocasts/nestjs-aws-sqs-connector",
-      "version": "0.0.1",
+      "version": "0.0.3",
       "license": "ISC",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.451.0",
@@ -25,7 +25,7 @@
         "ts-jest": "^27.1.5",
         "ts-node": "^10.9.1",
         "tsconfig-paths": "^3.14.2",
-        "typescript": "^4.9.5",
+        "typescript": "^5.3.2",
         "wait-for-expect": "^3.0.2"
       },
       "engines": {
@@ -7651,16 +7651,16 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=14.17"
       }
     },
     "node_modules/uid": {
@@ -13850,9 +13850,9 @@
       }
     },
     "typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true
     },
     "uid": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@flocasts/nestjs-aws-sqs-connector",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "",
   "main": "dist/index.js",
   "types": "dist/index.js.ts",
@@ -8,7 +8,7 @@
     "node": ">=16.10 <=20"
   },
   "scripts": {
-    "build": "tsc -p tsconfig.json",
+    "build": "npx tsc",
     "test": "jest",
     "package": "npm pack"
   },
@@ -40,7 +40,7 @@
     "ts-jest": "^27.1.5",
     "ts-node": "^10.9.1",
     "tsconfig-paths": "^3.14.2",
-    "typescript": "^4.9.5",
+    "typescript": "^5.3.2",
     "wait-for-expect": "^3.0.2"
   }
 }


### PR DESCRIPTION
I fixed the export as type - consumer libs didn't work because it was not a type I was re-exporting, it's a constant

Added the undefined check around the sqsClient

Upgraded TS library and build line item to npx - I had to do this due to module.ts not getting exported AND downstream JEST was looking for JS but it found TS, so after much research, upgrading TS fixed this.  TW and VOD are building and passing tests now thanks to this change.